### PR TITLE
Fix links to youtube

### DIFF
--- a/docs/coc.html
+++ b/docs/coc.html
@@ -106,7 +106,7 @@
             </a></li>
 
             <li><a
-                href="https://www.youtube.com/channel/UCIHsqY_4eWeInVQnxZ7WSjg" class="fa fa-youtube-play" title="YouTube">
+                href="https://www.youtube.com/channel/UCmYAQDZIQGm_kPvemBc_qwg" class="fa fa-youtube-play" title="YouTube">
                 <span class="hide">YouTube</span>
             </a></li>
 

--- a/docs/coc.html
+++ b/docs/coc.html
@@ -114,8 +114,9 @@
                 <span class="hide">Google+</span>
             </a></li>
 
-            <li><a href="http://www.winterofcode.com" title="Winter of Code">
-                <img src="img/winterofcode_logo_18x_30y.png" height=20 alt="Winter of Code"></a>
+            <li><a href="https://github.com/kejbaly2/devconfcz" class="fa fa-github" title="Github">
+                <span class="hide">GitHub</span>
+            </a></li>
           </ul>
         </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,7 @@
             </a></li>
 
             <li><a
-                href="https://www.youtube.com/channel/UCIHsqY_4eWeInVQnxZ7WSjg" class="fa fa-youtube-play" title="YouTube">
+                href="https://www.youtube.com/channel/UCmYAQDZIQGm_kPvemBc_qwg" class="fa fa-youtube-play" title="YouTube">
                 <span class="hide">YouTube</span>
             </a></li>
 

--- a/docs/media-policy.html
+++ b/docs/media-policy.html
@@ -106,7 +106,7 @@
             </a></li>
 
             <li><a
-                href="https://www.youtube.com/channel/UCIHsqY_4eWeInVQnxZ7WSjg" class="fa fa-youtube-play" title="YouTube">
+                href="https://www.youtube.com/channel/UCmYAQDZIQGm_kPvemBc_qwg" class="fa fa-youtube-play" title="YouTube">
                 <span class="hide">YouTube</span>
             </a></li>
 
@@ -147,7 +147,7 @@
             <p>As conference organizers, we cannot be all places at once and it is important for us to be able to review all material presented at the conference.  For this reason, you may not opt out of having your talk recorded.  However, if you wish, you may request that the session video not be published to the public.</p>
 
             <p>Visit the <a
-                href="https://www.youtube.com/channel/UCIHsqY_4eWeInVQnxZ7WSjg"><i class="fa fa-youtube-play"></i>DevConf.cz YouTube channel</a>.</p>
+                href="https://www.youtube.com/channel/UCmYAQDZIQGm_kPvemBc_qwg"><i class="fa fa-youtube-play"></i>DevConf.cz YouTube channel</a>.</p>
 
             <h3>Recording by Attendees</h3>
             <p>All sessions are recorded by official DevConf.cz or venue A/V staff. If you are not the speaker and wish to audio/video record, you must obtain written consent from the speaker first.</p>

--- a/docs/media-policy.html
+++ b/docs/media-policy.html
@@ -114,8 +114,9 @@
                 <span class="hide">Google+</span>
             </a></li>
 
-            <li><a href="http://www.winterofcode.com" title="Winter of Code">
-                <img src="img/winterofcode_logo_18x_30y.png" height=20 alt="Winter of Code"></a>
+            <li><a href="https://github.com/kejbaly2/devconfcz" class="fa fa-github" title="Github">
+                <span class="hide">GitHub</span>
+            </a></li>
           </ul>
         </div>
 

--- a/docs/schedule.html
+++ b/docs/schedule.html
@@ -119,7 +119,7 @@
             </a></li>
 
             <li><a
-                href="https://www.youtube.com/channel/UCIHsqY_4eWeInVQnxZ7WSjg" class="fa fa-youtube-play" title="YouTube">
+                href="https://www.youtube.com/channel/UCmYAQDZIQGm_kPvemBc_qwg" class="fa fa-youtube-play" title="YouTube">
                 <span class="hide">YouTube</span>
             </a></li>
 

--- a/docs/speaker-agreement.html
+++ b/docs/speaker-agreement.html
@@ -106,7 +106,7 @@
             </a></li>
 
             <li><a
-                href="https://www.youtube.com/channel/UCIHsqY_4eWeInVQnxZ7WSjg" class="fa fa-youtube-play" title="YouTube">
+                href="https://www.youtube.com/channel/UCmYAQDZIQGm_kPvemBc_qwg" class="fa fa-youtube-play" title="YouTube">
                 <span class="hide">YouTube</span>
             </a></li>
 

--- a/docs/speaker-agreement.html
+++ b/docs/speaker-agreement.html
@@ -114,8 +114,9 @@
                 <span class="hide">Google+</span>
             </a></li>
 
-            <li><a href="http://www.winterofcode.com" title="Winter of Code">
-                <img src="img/winterofcode_logo_18x_30y.png" height=20 alt="Winter of Code"></a>
+            <li><a href="https://github.com/kejbaly2/devconfcz" class="fa fa-github" title="Github">
+                <span class="hide">GitHub</span>
+            </a></li>
           </ul>
         </div>
 

--- a/docs/speakers.html
+++ b/docs/speakers.html
@@ -119,7 +119,7 @@
             </a></li>
 
             <li><a
-                href="https://www.youtube.com/channel/UCIHsqY_4eWeInVQnxZ7WSjg" class="fa fa-youtube-play" title="YouTube">
+                href="https://www.youtube.com/channel/UCmYAQDZIQGm_kPvemBc_qwg" class="fa fa-youtube-play" title="YouTube">
                 <span class="hide">YouTube</span>
             </a></li>
 


### PR DESCRIPTION
Hi,
it is not easy to find video from the DevConf 2017 because the youtube link leads to the RedHatCzech channel.

Also some pages still have the winterofcode link...